### PR TITLE
feat : time picker component

### DIFF
--- a/src/components/common/select.tsx
+++ b/src/components/common/select.tsx
@@ -1,31 +1,23 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { Listbox, Transition } from '@headlessui/react';
 
-const timezone = [
-  { time: '00:00' },
-  { time: '01:00' },
-  { time: '02:00' },
-  { time: '03:00' },
-  { time: '04:00' },
-  { time: '05:00' },
-  { time: '06:00' },
-  { time: '07:00' },
-  { time: '08:00' },
-  { time: '09:00' },
-  { time: '10:00' },
-  { time: '11:00' },
-  { time: '12:00' },
-];
+interface SelectProps {
+  options: { value: string }[];
+}
 
-export default function Select() {
-  const [selected, setSelected] = useState(timezone[0]);
+export default function Select({ options }: SelectProps) {
+  const [selected, setSelected] = useState(options[0]);
+
+  useEffect(() => {
+    setSelected(options[0]);
+  }, [options]);
 
   return (
     <div>
       <Listbox value={selected} onChange={setSelected}>
         <div className="relative">
           <Listbox.Button className="relative w-16 h-10 text-primary-green-3 cursor-default rounded-md text-h3 bg-secondary-orange-3 p-[1.5px] text-center focus:outline-none focus-visible:border-primary-green-1 ">
-            <span className="block truncate">{selected.time}</span>
+            <span className="block truncate">{selected.value}</span>
           </Listbox.Button>
           <Transition
             as={Fragment}
@@ -34,9 +26,9 @@ export default function Select() {
             leaveTo="opacity-0"
           >
             <Listbox.Options className="absolute mt-1 z-10 overflow-auto scrollbar-none scrollbar-track-transparent scrollbar-thumb-primary-green-1 scrollbar-thumb-rounded max-h-40 w-full rounded-md bg-secondary-orange-3 text-h3">
-              {timezone.map((person, personIdx) => (
+              {options.map((option, optionIdx) => (
                 <Listbox.Option
-                  key={personIdx}
+                  key={optionIdx}
                   className={({ active }) =>
                     `relative cursor-default select-none p-2 text-center ${
                       active
@@ -44,7 +36,7 @@ export default function Select() {
                         : 'text-primary-green-3'
                     }`
                   }
-                  value={person}
+                  value={option}
                 >
                   {({ selected }) => (
                     <>
@@ -53,7 +45,7 @@ export default function Select() {
                           selected ? 'font-medium' : 'font-normal'
                         }`}
                       >
-                        {person.time}
+                        {option.value}
                       </span>
                     </>
                   )}

--- a/src/components/common/time-picker.tsx
+++ b/src/components/common/time-picker.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import Select from './select';
+import Toggle from './toggle';
+
+const dayTimeZone = [
+  { value: '00:00' },
+  { value: '01:00' },
+  { value: '02:00' },
+  { value: '03:00' },
+  { value: '04:00' },
+  { value: '05:00' },
+  { value: '06:00' },
+  { value: '07:00' },
+  { value: '08:00' },
+  { value: '09:00' },
+  { value: '10:00' },
+  { value: '11:00' },
+  { value: '12:00' },
+];
+
+const nightTimeZone = [
+  { value: '13:00' },
+  { value: '14:00' },
+  { value: '15:00' },
+  { value: '16:00' },
+  { value: '17:00' },
+  { value: '18:00' },
+  { value: '19:00' },
+  { value: '20:00' },
+  { value: '21:00' },
+  { value: '22:00' },
+  { value: '23:00' },
+  { value: '24:00' },
+];
+
+export default function TimePicker() {
+  const [dayOrNight, setDayOrNight] = useState(true);
+  const [options, setOptions] = useState(dayTimeZone);
+
+  useEffect(() => {
+    if (dayOrNight) setOptions(nightTimeZone);
+    else setOptions(dayTimeZone);
+  }, [dayOrNight, setOptions]);
+
+  return (
+    <div className="flex justify-center items-center">
+      <Select options={options} />
+      <Toggle
+        enabled={dayOrNight}
+        onClick={() => {
+          setDayOrNight((prev) => !prev);
+        }}
+        toggleMenu={['AM', 'PM']}
+        className="ml-1"
+      />
+    </div>
+  );
+}

--- a/src/components/common/toggle.tsx
+++ b/src/components/common/toggle.tsx
@@ -3,20 +3,23 @@ import { Switch } from '@headlessui/react';
 
 interface ToggleProps {
   enabled?: boolean;
-  toggleMenu?: [string, string];
+  toggleMenu?: string[];
   className?: string;
+  [key: string]: any;
 }
 
 export default function Toggle({
   enabled,
   toggleMenu,
   className,
+  ...rest
 }: ToggleProps) {
   const [isEnabled, setIsEnabled] = useState(enabled);
   return (
     <Switch
       checked={enabled}
       onChange={setIsEnabled}
+      {...rest}
       className={
         `relative inline-flex text-primary-green-3 text-h3 justify-around h-10 w-24 items-center rounded-md bg-secondary-orange-3` +
         (className ? ` ${className}` : '')

--- a/src/components/common/toggle.tsx
+++ b/src/components/common/toggle.tsx
@@ -2,29 +2,49 @@ import { useState } from 'react';
 import { Switch } from '@headlessui/react';
 
 interface ToggleProps {
+  enabled?: boolean;
+  toggleMenu?: [string, string];
   className?: string;
 }
 
-export default function Toggle({ className }: ToggleProps) {
-  const [enabled, setEnabled] = useState(false);
-
+export default function Toggle({
+  enabled,
+  toggleMenu,
+  className,
+}: ToggleProps) {
+  const [isEnabled, setIsEnabled] = useState(enabled);
   return (
     <Switch
       checked={enabled}
-      onChange={setEnabled}
+      onChange={setIsEnabled}
       className={
         `relative inline-flex text-primary-green-3 text-h3 justify-around h-10 w-24 items-center rounded-md bg-secondary-orange-3` +
         (className ? ` ${className}` : '')
       }
     >
-      <span>AM</span>
-      <span>PM</span>
+      {toggleMenu ? (
+        <div className="inline-flex justify-around w-full">
+          <span>{toggleMenu[0]}</span>
+          <span>{toggleMenu[1]}</span>
+        </div>
+      ) : (
+        <div className="inline-flex justify-around w-full">
+          <span>OFF</span>
+          <span>ON</span>
+        </div>
+      )}
       <span
         className={`${
-          enabled ? 'translate-x-12' : 'translate-x-1'
+          isEnabled ? 'translate-x-12' : 'translate-x-1'
         } absolute -left-0 flex justify-center items-center text-h3 h-8 w-11 transform rounded-md text-white bg-primary-green-1 transition`}
       >
-        {enabled ? 'PM' : 'AM'}
+        {toggleMenu ? (
+          <span className="text-h3">
+            {isEnabled ? toggleMenu[1] : toggleMenu[0]}
+          </span>
+        ) : (
+          <span className="text-h3">{isEnabled ? 'ON' : 'OFF'}</span>
+        )}
       </span>
     </Switch>
   );


### PR DESCRIPTION
- select, toggle component를 재사용이 가능하게 몇몇 state들을 props로 옮겨주었습니다. 
- 두개의 기본 컴포넌트를 가지고 time-picker 컴포넌트를 만들었습니다. 
- 오른쪽 toggle을 통해 AM <-> PM을 바꾸면 왼쪽 select의 opiton들이 바뀝니다.
<img width="255" alt="image" src="https://user-images.githubusercontent.com/92621861/209463798-2f883767-ab76-4c37-9c13-12e9b1f091bc.png">
