### PR TITLE
refactoring and set user schedule availability as global

### DIFF
--- a/src/apis/useMutation.ts
+++ b/src/apis/useMutation.ts
@@ -19,7 +19,7 @@ export default function useMutation<T = any>(
 
   function mutation(data: any) {
     setState((prev) => ({ ...prev, loading: true }));
-    fetch(`${CONFIG.API_BASE_URL}/api${url}`, {
+    fetch(`${CONFIG.API_BASE_URL}${url}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/components/update/calender-schedule.tsx
+++ b/src/components/update/calender-schedule.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
 import { formatDate } from '@utils/calender';
 import { useAppDispatch, useAppSelector } from '@features/hooks';
+import { eventState } from '@features/event/eventSlice';
 import { setCurrnet } from '@features/schedule/scheduleSlice';
+import useSWR from 'swr';
+import { useRouter } from 'next/router';
 const monthNames = [
   'January',
   'February',
@@ -24,8 +27,12 @@ export default function ScheduleCalender() {
   const [days, setDays] = useState([]);
   const [chosenDays, setChosenDays] = useState([]);
   const dispatch = useAppDispatch();
-  const eventState = useAppSelector((state) => state.event);
   const scheduleState = useAppSelector((state) => state.schedule);
+
+  const router = useRouter();
+  const { data, isLoading } = useSWR<eventState>(
+    `/api/events/${router.query.uuid}}/`,
+  );
 
   useEffect(() => {
     const firstDay = new Date(year, month, 1);
@@ -38,29 +45,29 @@ export default function ScheduleCalender() {
     for (let i = 1; i <= numberOfDays; i++) {
       daysArray.push(i);
     }
-
     for (let i = 0; i < firstDayIndex; i++) {
       daysArray.unshift('');
     }
-
     for (let i = lastDayIndex; i < 6; i++) {
       daysArray.push('');
     }
     setDays(daysArray);
 
-    const chosenDaysArray = daysArray.map((day) => {
-      if (day !== '') return false;
-    });
+    if (isLoading) return;
 
-    // set chosen days
-    Object.keys(eventState.availability).forEach((date) => {
-      const dateArray = date.split('-');
-      if (+dateArray[0] === year && +dateArray[1] === month + 1) {
-        chosenDaysArray[+dateArray[2] + firstDayIndex - 1] = true;
-      }
-    });
-    setChosenDays(chosenDaysArray);
-  }, [month, year, eventState.additional_dates, eventState.availability]);
+    if (data) {
+      const chosenDaysArray = daysArray.map((day) => {
+        if (day !== '') return false;
+      });
+      Object.keys(data.availability).forEach((date) => {
+        const dateArray = date.split('-');
+        if (+dateArray[0] === year && +dateArray[1] === month + 1) {
+          chosenDaysArray[+dateArray[2] + firstDayIndex - 1] = true;
+        }
+      });
+      setChosenDays(chosenDaysArray);
+    }
+  }, [month, year, data, isLoading]);
 
   const nextMonth = () => {
     if (month === 11) {

--- a/src/features/schedule/scheduleSlice.ts
+++ b/src/features/schedule/scheduleSlice.ts
@@ -29,7 +29,7 @@ const scheduleSlice = createSlice({
       ...state,
       availability: {
         ...state.availability,
-        [action.payload.date]: action.payload.available, // current:'000000000000000111100000'
+        [action.payload.date]: action.payload.availability, // current:'000000000000000111100000'
       },
     }),
     setCurrnet: (state, action) => ({

--- a/src/features/schedule/scheduleSlice.ts
+++ b/src/features/schedule/scheduleSlice.ts
@@ -10,7 +10,7 @@ const initialState: scheduleState = {
   name: '',
   event: undefined,
   current: '',
-  availability: {}, // {'2021-01-01': '000000000000000111100000'} // 0 = not available, 1 = available
+  availability: {},
 };
 
 const scheduleSlice = createSlice({
@@ -29,7 +29,7 @@ const scheduleSlice = createSlice({
       ...state,
       availability: {
         ...state.availability,
-        [action.payload.date]: action.payload.availability, // current:'000000000000000111100000'
+        [action.payload.date]: action.payload.availability,
       },
     }),
     setCurrnet: (state, action) => ({

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,6 +13,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <SWRConfig
       value={{
+        refreshInterval: 3000,
         fetcher: (url: string) => instance.get(url).then((res) => res.data),
       }}
     >

--- a/src/pages/events/create/index.tsx
+++ b/src/pages/events/create/index.tsx
@@ -5,15 +5,11 @@ import Input from '@components/common/input';
 import { useForm } from 'react-hook-form';
 import { setTitle } from '@features/event/eventSlice';
 import { useAppDispatch, useAppSelector } from '@features/hooks';
-import useSWR from 'swr';
-import eventApi from '@apis/event/eventApi';
 interface EventForm {
   title: string;
 }
 
 function Create() {
-  const { data, error, isLoading } = useSWR('/events', eventApi.getEventList);
-
   const router = useRouter();
   const dispatch = useAppDispatch();
   const titleState = useAppSelector((state) => state.event.title);

--- a/src/pages/events/create/schedule.tsx
+++ b/src/pages/events/create/schedule.tsx
@@ -4,9 +4,9 @@ import Calender from '@components/common/calender';
 import Button from '@components/common/button';
 import TimePicker from '@components/common/time-picker';
 import { useForm } from 'react-hook-form';
-import { useAppDispatch, useAppSelector } from '@features/hooks';
-import { setTime } from '@features/event/eventSlice';
+import { useAppSelector } from '@features/hooks';
 import useMutation from '@apis/useMutation';
+import { useEffect } from 'react';
 
 type time = {
   value: string;
@@ -23,41 +23,32 @@ interface EventMutaionResponse {
 
 function Schedule() {
   const { setValue, handleSubmit } = useForm<ScheuleForm>();
-  const dispatch = useAppDispatch();
   const eventState = useAppSelector((state) => state.event);
   const router = useRouter();
 
-  const [createEvent, { data, error, loading }] =
-    useMutation<EventMutaionResponse>('/events/');
+  const [createEvent, { data, loading }] =
+    useMutation<EventMutaionResponse>('/api/events/');
 
   const onValid = (form: ScheuleForm) => {
     const { start_time, end_time } = form;
-    dispatch(
-      setTime({ start_time: start_time.value, end_time: end_time.value }),
-    );
-
     if (start_time.value > end_time.value) {
       alert(
         'Please check the time you entered. The start time must be earlier than the end time.',
       );
       return;
     }
-
     createEvent({
       title: eventState.title,
       startTime: start_time.value,
       endTime: end_time.value,
     });
-
-    if (data) {
-      console.log(data);
-
-      router.push({
-        pathname: '/events/create/summary',
-        query: { id: data.id, uuid: data.uuid },
-      });
-    }
   };
+
+  useEffect(() => {
+    if (data) {
+      router.push(`/events/create/summary?uuid=${data.uuid}`);
+    }
+  }, [data, router]);
 
   return (
     <Layout>

--- a/src/pages/events/update/index.tsx
+++ b/src/pages/events/update/index.tsx
@@ -5,8 +5,6 @@ import Input from '@components/common/input';
 import { useForm } from 'react-hook-form';
 import { useAppDispatch } from '@features/hooks';
 import { setName } from '@features/schedule/scheduleSlice';
-import { useEffect } from 'react';
-import { setAvailability, setTime } from '@features/event/eventSlice';
 import useSWR from 'swr';
 import { eventState } from '@features/event/eventSlice';
 interface UserForm {
@@ -19,15 +17,6 @@ function Update() {
   const { data, isLoading } = useSWR<eventState>(`/api/events/${uuid}}/`);
 
   const dispatch = useAppDispatch();
-  useEffect(() => {
-    if (isLoading) return;
-    dispatch(setAvailability(data.availability));
-    const time_rage = {
-      start_time: data.start_time,
-      end_time: data.end_time,
-    };
-    dispatch(setTime(time_rage));
-  }, [dispatch, data, isLoading]);
 
   const {
     handleSubmit,

--- a/src/pages/events/update/index.tsx
+++ b/src/pages/events/update/index.tsx
@@ -50,7 +50,7 @@ function Update() {
       <div className="w-full flex flex-col items-center justify-center h-full">
         <div className="w-full flex flex-col items-center justify-center mb-8">
           <h1 className="text-display font-bold text-center text-primary-green-1">
-            Event Title
+            {data ? `${data.title}` : 'Event Title'}
           </h1>
         </div>
         <div className="w-full flex flex-col items-center justify-center mb-8">

--- a/src/pages/events/update/index.tsx
+++ b/src/pages/events/update/index.tsx
@@ -4,7 +4,7 @@ import Button from '@components/common/button';
 import Input from '@components/common/input';
 import { useForm } from 'react-hook-form';
 import { useAppDispatch } from '@features/hooks';
-import { setName } from '@features/schedule/scheduleSlice';
+import { setName, setAvailability } from '@features/schedule/scheduleSlice';
 import useSWR from 'swr';
 import { eventState } from '@features/event/eventSlice';
 interface UserForm {
@@ -25,13 +25,27 @@ function Update() {
   } = useForm<UserForm>({});
 
   const onSubmit = (form: UserForm) => {
+    if (isLoading || !data) return;
+
     const { name } = form;
     dispatch(setName(name));
-    if (name)
-      router.push({
-        pathname: '/events/update/schedule',
-        query: { uuid },
-      });
+
+    // 이미 있는 유저인지 확인하고 다른 path로 보내야함
+
+    // 새로운 유저인 경우
+    Object.keys(data.availability).forEach((key) => {
+      dispatch(
+        setAvailability({
+          date: key,
+          availability: '000000000000000000000000000000000000000000000000',
+        }),
+      );
+    });
+
+    router.push({
+      pathname: '/events/update/schedule',
+      query: { uuid },
+    });
   };
 
   return (

--- a/src/pages/events/update/schedule.tsx
+++ b/src/pages/events/update/schedule.tsx
@@ -2,11 +2,13 @@ import { useRouter } from 'next/router';
 import Layout from '@components/common/layout';
 import Button from '@components/common/button';
 import { useForm } from 'react-hook-form';
-import { useAppSelector } from '@features/hooks';
+import { useAppDispatch, useAppSelector } from '@features/hooks';
 import { useEffect, useState } from 'react';
 import ScheduleCalender from '@components/update/calender-schedule';
 import { eventState } from '@features/event/eventSlice';
+import { setAvailability as setScheduleAvailability } from '@features/schedule/scheduleSlice';
 import useSWR from 'swr';
+import useMutation from '@apis/useMutation';
 
 const TIMEZONE = [
   '00:00',
@@ -59,56 +61,60 @@ const TIMEZONE = [
   '23:30',
 ];
 
+interface Scheule {
+  name: string;
+  availability: string[];
+}
+
 function Schedule() {
-  const { setValue, handleSubmit, watch } = useForm();
+  const { handleSubmit } = useForm();
   const router = useRouter();
-  const { data, isLoading } = useSWR<eventState>(
+  const { data, isLoading, mutate } = useSWR<eventState>(
     `/api/events/${router.query.uuid}}/`,
   );
+
+  const [updateSchedule, { data: updateData, error, loading }] = useMutation(
+    `/api/events/${router.query.uuid}/schedules/`,
+  );
+
+  // 이벤트 정보 가져옴
   const [event, setEvent] = useState<eventState>();
   const [timeTable, setTimeTable] = useState([]);
-  const [availability, setAvailability] = useState<boolean[]>([]);
+
+  // 유저 스케줄 가져옴 여기서는 사용하지 않음
+  const [schedule, setSchedule] = useState<Scheule>();
+
+  const scheduleState = useAppSelector((state) => state.schedule);
+  console.log(scheduleState);
 
   useEffect(() => {
     if (isLoading) return;
     setEvent(data);
   }, [data, isLoading]);
 
+  const dispatch = useAppDispatch();
   useEffect(() => {
+    if (isLoading) return;
     if (!event) return;
     const startIndex = TIMEZONE.indexOf(event.start_time);
     const endIndex = TIMEZONE.indexOf(event.end_time);
     const timeRange = TIMEZONE.slice(startIndex, endIndex + 1);
-    const possibleArray = timeRange.map(() => false);
-    setAvailability(possibleArray);
     setTimeTable(timeRange);
-  }, [event]);
-
-  // availability to string for backend
-  useEffect(() => {
-    if (!event) return;
-    let availabilityString = availability.map((a) => (a ? '1' : '0')).join('');
-    const startIndex = TIMEZONE.indexOf(event.start_time);
-    for (let i = 0; i < startIndex; i++) {
-      availabilityString = '0' + availabilityString;
-    }
-    const endIndex = TIMEZONE.indexOf(event.end_time);
-    for (let i = 0; i < 47 - endIndex; i++) {
-      availabilityString = availabilityString + '0';
-    }
-    setValue('availability', availabilityString);
-  }, [availability, event, setValue]);
-
-  const watchAllFields = watch('availability');
-  console.log(watchAllFields);
-
-  const scheduleState = useAppSelector((state) => state.schedule);
+  }, [event, isLoading]);
 
   const onTimeTableClick = (time: string) => {
-    const index = timeTable.indexOf(time);
-    const newAvailability = [...availability];
-    newAvailability[index] = !newAvailability[index];
-    setAvailability(newAvailability);
+    const index = TIMEZONE.indexOf(time);
+    const availability = scheduleState.availability[scheduleState.current];
+    const newAvailability =
+      availability.slice(0, index) +
+      (availability[index] === '0' ? '1' : '0') +
+      availability.slice(index + 1);
+    dispatch(
+      setScheduleAvailability({
+        date: scheduleState.current,
+        availability: newAvailability,
+      }),
+    );
   };
 
   const onValid = (form) => {
@@ -123,7 +129,7 @@ function Schedule() {
       >
         <div className="w-full flex flex-col items-center justify-center mb-8">
           <h1 className="text-display font-bold text-center text-base-black">
-            Event Title
+            {event.title ? event.title : 'Event Title'}
           </h1>
         </div>
         <div className="w-full flex items-center justify-center">
@@ -144,7 +150,9 @@ function Schedule() {
                 </div>
                 <div
                   className={`w-4/5 rounded-lg h-14 mr-2 ${
-                    availability[index]
+                    scheduleState.availability[scheduleState.current][
+                      TIMEZONE.indexOf(time)
+                    ] === '1'
                       ? 'bg-primary-green-1'
                       : 'bg-secondary-orange-3'
                   }`}

--- a/src/pages/events/update/schedule.tsx
+++ b/src/pages/events/update/schedule.tsx
@@ -129,7 +129,7 @@ function Schedule() {
       >
         <div className="w-full flex flex-col items-center justify-center mb-8">
           <h1 className="text-display font-bold text-center text-base-black">
-            {event.title ? event.title : 'Event Title'}
+            {event && event.title ? event.title : 'Event Title'}
           </h1>
         </div>
         <div className="w-full flex items-center justify-center">


### PR DESCRIPTION
- 전역 state를 사용하지 않아도 되는 경우 최대한 사용하지 않도록 리팩토링을 진행했습니다. (local, global, server state 값이 서로 구분되어야 합니다.)
- /update 에서 이름을 입력시 이미 있는 유저인지 아니면 새로운 유저인지에 따라서 다른 페이지로 이동시킵니다. 
- /update 페이지에서 이름 제출시 schedule을 전역변수로 생성합니다. 
- 최종 폼 제출 전까지는 전역변수로 상태관리를 합니다. 